### PR TITLE
Removed explicit default proxy value

### DIFF
--- a/cmd/sblookup/main.go
+++ b/cmd/sblookup/main.go
@@ -42,7 +42,7 @@ var (
 	apiKeyFlag    = flag.String("apikey", "", "specify your Safe Browsing API key")
 	databaseFlag  = flag.String("db", "", "path to the Safe Browsing database. By default persistent storage is disabled (not recommended).")
 	serverURLFlag = flag.String("server", safebrowsing.DefaultServerURL, "Safebrowsing API server address.")
-	proxyFlag     = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
+	proxyFlag     = flag.String("proxy", "", "proxy to use to connect to the HTTP server")
 )
 
 const usage = `sblookup: command-line tool to lookup URLs with Safe Browsing.

--- a/cmd/sbserver/main.go
+++ b/cmd/sbserver/main.go
@@ -222,7 +222,7 @@ const (
 var (
 	apiKeyFlag   = flag.String("apikey", "", "specify your Safe Browsing API key")
 	srvAddrFlag  = flag.String("srvaddr", "localhost:8080", "TCP network address the HTTP server should use")
-	proxyFlag    = flag.String("proxy", os.Getenv("HTTP_PROXY"), "proxy to use to connect to the HTTP server")
+	proxyFlag    = flag.String("proxy", "", "proxy to use to connect to the HTTP server")
 	databaseFlag = flag.String("db", "", "path to the Safe Browsing database.")
 )
 


### PR DESCRIPTION
Setting the default proxy value to HTTP_PROXY induced confusion, and non-conformity with the previous behavior of the library.

HTTP_PROXY and NO_PROXY are still used though, through "net/http" and "Transport".